### PR TITLE
add insert query

### DIFF
--- a/src/Grammar/Grammar.php
+++ b/src/Grammar/Grammar.php
@@ -27,6 +27,8 @@ abstract class Grammar
                 return $this->generateSelectSql($query);
             case QueryType::UPDATE:
                 return $this->generateUpdateSql($query);
+            case QueryType::INSERT:
+                return $this->generateInsertSql($query);
             case QueryType::DELETE:
                 return $this->generateDeleteSql($query);
             case null:
@@ -39,6 +41,8 @@ abstract class Grammar
     abstract public function generateSelectSql(QueryBuilder $query): string;
 
     abstract public function generateUpdateSql(QueryBuilder $query): string;
+
+    abstract public function generateInsertSql(QueryBuilder $query): string;
 
     abstract public function generateDeleteSql(QueryBuilder $query): string;
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -19,9 +19,29 @@ abstract class Query
         return static::getInstance()->update($table);
     }
 
+    public static function insert(): QueryBuilder
+    {
+        return static::getInstance()->insert();
+    }
+
+    public static function into(string $table): QueryBuilder
+    {
+        return static::getInstance()->into($table);
+    }
+
     public static function delete(): QueryBuilder
     {
         return static::getInstance()->delete();
+    }
+
+    public static function set(string $column, int|string $value): QueryBuilder
+    {
+        return static::getInstance()->set($column, $value);
+    }
+
+    public static function values(array $values): QueryBuilder
+    {
+        return static::getInstance()->values($values);
     }
 
     protected static function getInstance(): QueryBuilder

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -90,6 +90,12 @@ class QueryBuilder
         return $this->from($table);
     }
 
+    public function values(array $values): static
+    {
+        $this->values = $values;
+        return $this;
+    }
+
     public function delete(): static
     {
         $this->queryType = QueryType::DELETE;
@@ -99,12 +105,6 @@ class QueryBuilder
     public function set(string $column, int|string $value): static
     {
         $this->sets[$column] = $value;
-        return $this;
-    }
-
-    public function values(array $values): static
-    {
-        $this->values = $values;
         return $this;
     }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -22,6 +22,9 @@ class QueryBuilder
     /** @var array<string|int> */
     protected array $sets = [];
 
+    /** @var array<int|string> */
+    protected array $values = [];
+
     /** @var array<array<int|string>> */
     protected array $wheres = [];
 
@@ -76,6 +79,17 @@ class QueryBuilder
         return $this;
     }
 
+    public function insert(): static
+    {
+        $this->queryType = QueryType::INSERT;
+        return $this;
+    }
+
+    public function into(string $table): static
+    {
+        return $this->from($table);
+    }
+
     public function delete(): static
     {
         $this->queryType = QueryType::DELETE;
@@ -85,6 +99,12 @@ class QueryBuilder
     public function set(string $column, int|string $value): static
     {
         $this->sets[$column] = $value;
+        return $this;
+    }
+
+    public function values(array $values): static
+    {
+        $this->values = $values;
         return $this;
     }
 
@@ -153,6 +173,14 @@ class QueryBuilder
     public function getSets(): array
     {
         return $this->sets;
+    }
+
+    /**
+     * @return array<int|string>
+     */
+    public function getValues(): array
+    {
+        return $this->values;
     }
 
     /**

--- a/tests/Unit/QueryBuilderTest.php
+++ b/tests/Unit/QueryBuilderTest.php
@@ -365,3 +365,30 @@ it('can set a query type to delete', function () {
 
     expect($queryBuilder->getQueryType())->toBe(QueryType::DELETE);
 });
+
+it('can set a query type to insert', function () {
+    $queryBuilder = new QueryBuilder();
+    $queryBuilder->insert();
+
+    expect($queryBuilder->getQueryType())->toBe(QueryType::INSERT);
+});
+
+it('can insert into a table', function () {
+    $queryBuilder = new QueryBuilder();
+    $queryBuilder->into('wp_posts');
+
+    expect($queryBuilder->getTable())->toBe('wp_posts');
+});
+
+it('can insert values', function () {
+    $queryBuilder = new QueryBuilder();
+    $queryBuilder->values([
+        'id' => 1,
+        'name' => 'John',
+    ]);
+
+    expect($queryBuilder->getValues())->toBe([
+        'id' => 1,
+        'name' => 'John',
+    ]);
+});


### PR DESCRIPTION
# Pull Request

## Description

Added an insert operator. Example usage:
```php
$results = Query::insert()
->into('wp_posts')
->values([
    'post_title' => 'Test',
    'post_content' => 'Test',
    'post_status' => 'publish',
])->execute();
```

## Type of Change

Please mark the appropriate box below:

- [ ] Bug Fix
- [x] New Feature
- [ ] Enhancement
- [ ] Documentation Update
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Other (please specify)

## Checklist

- [x] I have tested my changes locally.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the project's coding standards.
- [x] I have added or modified tests to cover my changes.
- [x] All new and existing tests pass successfully.
- [ ] I have updated the changelog (if applicable).
- [ ] I have addressed any reviewer comments or feedback.

## Contributor License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the [project's license](https://github.com/bitfactory-nl/wpqb/blob/main/LICENSE) and that I have the right to submit this work.
